### PR TITLE
Update remote url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='BSD License',
     description='A simple Django app that will give you a UserForeignKey model field.',
     long_description=README,
-    url='https://ks.co.at/',
+    url='https://github.com/beachmachine/django-userforeignkey/',
     author='Andreas Stocker',
     author_email='andreas@ks.co.at',
     classifiers=[


### PR DESCRIPTION
Change the URL to point to the github repository. This will make it easier to find the repository form https://pypi.org/project/django-userforeignkey/