### PR TITLE
Added support for async Django applications

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        django-version: ['2.2', '3.2']
         experimental: [false]
         include:
           - python-version: pypy3

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,9 @@ Django UserForeignKey is a simple Django app that will give you a `UserForeignKe
 This field extends a regular ForeignKey model field, and has the option to automatically set the currently logged in user on
 insert and/or update.
 
-Currently, Django 2.2 (Python 3.6+) and Django 3.2 (Python 3.6+) are supported.
+Currently, Django 2.2 (Python 3.7+) and Django 3.2 (Python 3.7+) are supported.
+
+If you need support for the insecure and deprecated Python 3.6, please fall back to version 0.4.0.
 
 If you need support for the insecure and deprecated Django 1.11 and/or Python2, please fall back to version 0.3.0.
 

--- a/django_userforeignkey/request.py
+++ b/django_userforeignkey/request.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+import contextvars
 import logging
-
-from threading import local
 
 from django.contrib.auth.models import AnonymousUser
 
-_thread_locals = local()
+current_request = contextvars.ContextVar("Current request")
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +17,7 @@ def set_current_request(request):
     :return:
     """
     logger.debug(u"Save request in current thread")
-    return setattr(_thread_locals, '__django_userforeignkey__current_request', request)
+    return current_request.set(request)
 
 
 def get_current_request():
@@ -26,7 +26,7 @@ def get_current_request():
 
     :return: Django request object
     """
-    return getattr(_thread_locals, '__django_userforeignkey__current_request', None)
+    return current_request.get(None)
 
 
 def get_current_user():

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Added support for async Django applications by using `contextvars` instead of `local()` which is the official recommendation by Python.